### PR TITLE
s/Hyper Interaktiv AS/Hyper/

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ it, simply add the following line to your Podfile:
 
 ## Author
 
-Hyper Interaktiv AS, teknologi@hyper.no
+Hyper, teknologi@hyper.no
 
 ## License
 


### PR DESCRIPTION
While our registered name remains Hyper Interaktiv in the Brønnøysund
register, we're Hyper for all intents and purposes. I went ahead and
removed "AS", too, as it is a Norwegian term. If we want to keep it
I think we should change it to "Inc".