### PR TITLE
Add base Swift class using Stencil

### DIFF
--- a/Pod/StencilPlugin/File Templates/Custom/BaseClass.xctemplate/TemplateInfo.plist
+++ b/Pod/StencilPlugin/File Templates/Custom/BaseClass.xctemplate/TemplateInfo.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>This is the template for a base Class in Swift</string>
+	<key>MainTemplateFile</key>
+	<string>___FILEBASENAME___</string>
+	<key>SortOrder</key>
+	<integer>3</integer>
+	<key>Platforms</key>
+	<array>
+		<string>com.apple.platform.iphoneos</string>
+	</array>
+</dict>
+</plist>

--- a/Pod/StencilPlugin/File Templates/Custom/BaseClass.xctemplate/___FILEBASENAME___.swift
+++ b/Pod/StencilPlugin/File Templates/Custom/BaseClass.xctemplate/___FILEBASENAME___.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+class ___FILEBASENAMEASIDENTIFIER___ {
+
+}


### PR DESCRIPTION
- Removes the attribution headers by using a [Stencil](http://sam.dods.co/stencil-xcode-plugin/) template
